### PR TITLE
Improve responsive UI

### DIFF
--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/analysis/convergence_analysis.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/analysis/convergence_analysis.py
@@ -114,7 +114,7 @@ def compute_convergence(lambda_fixed, n_mode_max, geometry, wave, df_config, jso
 stable_required_widget = widgets.IntText(
     value=3, 
     description="Stable required:", 
-    layout=widgets.Layout(width='150px')
+    layout=widgets.Layout(width='auto', flex='1 1 0%')
 )
 
 
@@ -132,7 +132,7 @@ def create_multi_convergence_widget(json_combined_path, all_configs):
     conv_config_selector = widgets.SelectMultiple(
         options=[(cfg["config_name"], cfg) for cfg in all_configs],
         description="Config convergence:",
-        layout=widgets.Layout(width='580px'),
+        layout=widgets.Layout(width='auto', flex='1 1 0%'),
         style={'description_width': 'initial'}
     )
     
@@ -169,22 +169,22 @@ def create_multi_convergence_widget(json_combined_path, all_configs):
     lambda_fixed_widget = widgets.FloatText(
         value=700.0, 
         description="λ fixe (nm):", 
-        layout=widgets.Layout(width='150px')
+        layout=widgets.Layout(width='auto', flex='1 1 0%')
     )
     n_mode_max_widget = widgets.IntText(
         value=100, 
         description="n_mode max:", 
-        layout=widgets.Layout(width='150px')
+        layout=widgets.Layout(width='auto', flex='1 1 0%')
     )
     n_mode_step_widget = widgets.IntText(
         value=1, 
         description="Step n_mode:", 
-        layout=widgets.Layout(width='150px')
+        layout=widgets.Layout(width='auto', flex='1 1 0%')
     )
     tolerance_widget = widgets.FloatText(
         value=1e-3, 
         description="Tolérance:", 
-        layout=widgets.Layout(width='150px')
+        layout=widgets.Layout(width='auto', flex='1 1 0%')
     )
     
     # Validation pour empêcher les valeurs négatives
@@ -214,7 +214,7 @@ def create_multi_convergence_widget(json_combined_path, all_configs):
         min=0, 
         max=1,  # sera défini lors du déclenchement du calcul
         description='Progress:',
-        layout=widgets.Layout(width='400px')
+        layout=widgets.Layout(width='auto', flex='1 1 0%')
     )
     
     #spacer = widgets.HBox([], layout=widgets.Layout(flex='1 1 auto'))
@@ -228,14 +228,14 @@ def create_multi_convergence_widget(json_combined_path, all_configs):
     conv_output = widgets.Output(
         layout=widgets.Layout(
             border="1px solid lightgray",
-            width='630px',
+            width='auto', flex='1 1 0%',
             height='450px' 
         )
     )
     
     # Widget pour afficher les résultats dans un tableau
     results_table_output = widgets.Output(
-        layout=widgets.Layout(border="1px solid lightgray", width='630px', max_height='200px', overflow='auto')
+        layout=widgets.Layout(border="1px solid lightgray", width='auto', flex='1 1 0%', max_height='200px', overflow='auto')
     )
     
     # Lien HTML qui deviendra le bouton de téléchargement

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/materials/geometry__material__config.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/materials/geometry__material__config.py
@@ -74,14 +74,14 @@ def create_geometry_material_widget():
         opts = [(c["config_name"], c) for c in geom_data] or [("—", None)]
         return widgets.Dropdown(
             options=opts, value=opts[0][1],
-            layout=widgets.Layout(width="240px")
+            layout=widgets.Layout(width="auto", flex="1 1 0%")
         )
 
     def _mat_dd():
         opts = [(c["config_name"], c) for c in mat_data] or [("—", None)]
         return widgets.Dropdown(
             options=opts, value=opts[0][1],
-            layout=widgets.Layout(width="240px")
+            layout=widgets.Layout(width="auto", flex="1 1 0%")
         )
 
     # ╭─ 2 |  Ligne “tableau” (geom • mat • 🗑️)  ───────────────────────────╮
@@ -90,7 +90,7 @@ def create_geometry_material_widget():
     def _add_row(_=None):
         geom, mat = _geom_dd(), _mat_dd()
         trash = widgets.Button(icon="trash", tooltip="Delete row",
-                               layout=widgets.Layout(width="38px"),
+                               layout=widgets.Layout(width="auto", flex="1 1 0%"),
                                button_style="danger")
         row = widgets.HBox([geom, mat, trash],
                            layout=widgets.Layout(gap="6px", align_items="center"))
@@ -112,10 +112,10 @@ def create_geometry_material_widget():
     # ╭─ 3 |  Actions globales  ─────────────────────────────────────────────╮
     btn_add  = widgets.Button(icon="plus",  tooltip="Add a new row",
                               button_style="info",
-                              layout=widgets.Layout(width="38px"))
+                              layout=widgets.Layout(width="auto", flex="1 1 0%"))
     btn_save = widgets.Button(icon="check", tooltip="Combine & save selections",
                               button_style="success",
-                              layout=widgets.Layout(width="38px"))
+                              layout=widgets.Layout(width="auto", flex="1 1 0%"))
 
     btn_add.on_click(_add_row)
 
@@ -123,7 +123,7 @@ def create_geometry_material_widget():
     saved_sel = widgets.SelectMultiple(layout=widgets.Layout(height="140px"))
     btn_del_saved = widgets.Button(icon="trash", button_style="danger",
                                    tooltip="Delete selected combos",
-                                   layout=widgets.Layout(width="38px"))
+                                   layout=widgets.Layout(width="auto", flex="1 1 0%"))
     saved_box = widgets.HBox([saved_sel, btn_del_saved],
                              layout=widgets.Layout(gap="6px"))
     acc_saved = widgets.Accordion(children=[saved_box])
@@ -242,7 +242,7 @@ def create_geometry_material_widget():
 
     panel = widgets.VBox(
         [style, header, rows_box, buttons_bar, acc_saved, status],
-        layout=widgets.Layout(width="680px", gap="6px"),
+        layout=widgets.Layout(width="auto", flex="1 1 0%", gap="6px"),
     )
     # garde le watcher vivant
     panel._watcher = _watcher

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/optimisation/optimisation.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/optimisation/optimisation.py
@@ -267,7 +267,7 @@ class OptimizationFileArboWidget:
             self.budget_pop_dd, self.wave_dd,
             self.file_dd, self.run_dd
         ):
-            dd.layout = widgets.Layout(width="300px")
+            dd.layout = widgets.Layout(width="auto", flex="1 1 0%")
             # raccourcit un peu la zone de description
             dd.style = {"description_width": "initial"}
 
@@ -552,7 +552,7 @@ class OptimizationTab:
             value=True,                      # ouvert par défaut
             icon="caret-up",
             button_style="warning",
-            layout=widgets.Layout(width="520px")
+            layout=widgets.Layout(width="auto", flex="1 1 0%")
         )
         self.opt_toggle_btn.observe(self._toggle_config_list, names="value")
 
@@ -573,7 +573,7 @@ class OptimizationTab:
         for cfg_name in _load_available_configs():
             chk_cfg = widgets.Checkbox(value=False, description=cfg_name, indent=False)
             chk_dn  = widgets.Checkbox(value=False, description="Δn", indent=False,
-                                       layout=widgets.Layout(width="46px"))
+                                       layout=widgets.Layout(width="auto", flex="1 1 0%"))
 
             chk_dn.observe(self._update_dn_widgets_state, names="value")
 
@@ -591,7 +591,7 @@ class OptimizationTab:
         self.opt_config_list = widgets.VBox(
              rows,
             layout=widgets.Layout(
-                width="500px",
+                width="auto", flex="1 1 0%",
                 height=f"{30 + visible*30}px",
                 overflow_y="auto",
                 border="1px solid lightgray",
@@ -630,7 +630,7 @@ class OptimizationTab:
                                     description=cfg_name, indent=False)
             chk_dn  = widgets.Checkbox(value=prev_dn.get(cfg_name, False),
                                     description="Δn", indent=False,
-                                    layout=widgets.Layout(width="46px"))
+                                    layout=widgets.Layout(width="auto", flex="1 1 0%"))
             # rattacher callbacks
             chk_cfg.observe(self._refresh_parametrization,    names="value")
             chk_cfg.observe(self._opt_refresh_custom_modes,   names="value")
@@ -717,7 +717,7 @@ class OptimizationTab:
 
         self.common_bounds_controls = widgets.HBox(
             [
-                widgets.Label("Common bounds:", layout=widgets.Layout(width="200px")),
+                widgets.Label("Common bounds:", layout=widgets.Layout(width="auto", flex="1 1 0%")),
                 self.common_low_w,
                 self.common_up_w,
                 self.apply_bounds_btn
@@ -734,7 +734,7 @@ class OptimizationTab:
             options=['multi_layer', 'gap_plasmon_resonator'],
             value='multi_layer', description='Family:',
             style={'description_width': 'initial'},
-            layout=widgets.Layout(width='220px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
         )
 
 
@@ -751,7 +751,7 @@ class OptimizationTab:
             value='dip',
             
             style={'description_width': 'initial'},
-            layout=widgets.Layout(width='300px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
         )
 
         self._build_opt_config_selector()
@@ -775,21 +775,21 @@ class OptimizationTab:
             value='fixed',
             description='RCWA modes (opt)',
             style={'description_width': 'initial'},
-            layout=widgets.Layout(width='220px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
         )
 
         self.opt_fixed_n_mod = widgets.IntText(          # visible si 'fixed'
             value=5, min=1,
             description='n_mod',
             style={'description_width': 'initial'},
-            layout=widgets.Layout(width='120px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
         )
 
         self.opt_custom_modes_box = widgets.VBox(
             value=5, min=1,
             description='n_mod',
             style={'description_width': 'initial'},
-            layout=widgets.Layout(width='400px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
             )       
         
         self._opt_custom_n_mod_inputs: dict[str, widgets.IntText] = {}
@@ -811,17 +811,17 @@ class OptimizationTab:
 
         # Widgets spécifiques au mode 'fixed_lambda' ou 'range_lambda'
         self.lambda0_w = widgets.FloatText(
-            value=600, description="λ₀ (nm):", layout=widgets.Layout(width="400px")
+            value=600, description="λ₀ (nm):", layout=widgets.Layout(width="auto", flex="1 1 0%")
         )
         self.band_min_w = widgets.FloatText(
             value=650,
             description="λmin:",
-            layout=widgets.Layout(width="400px"),
+            layout=widgets.Layout(width="auto", flex="1 1 0%"),
         )
         self.band_max_w = widgets.FloatText(
             value=750,
             description="λmax:",
-            layout=widgets.Layout(width="400px"),
+            layout=widgets.Layout(width="auto", flex="1 1 0%"),
         )
         self.band_box = widgets.HBox(
             [self.band_min_w, self.band_max_w],
@@ -1274,7 +1274,7 @@ class OptimizationTab:
                     value=self.opt_fixed_n_mod.value,
                     description=name,
                     style={'description_width': 'initial'},
-                    layout=widgets.Layout(width='250px')
+                    layout=widgets.Layout(width='auto', flex='1 1 0%')
                 )
                 self._opt_custom_n_mod_inputs[name] = it
             inputs.append(it)
@@ -2463,10 +2463,10 @@ class OptimizationTab:
             # Affiche la figure groupée
             display(fig)
             # Ligne de boutons (un sous chaque subplot, donc 2x2)
-            dl_conv = widgets.Button(description="Télécharger Convergence", icon="download", layout=widgets.Layout(width="200px"))
-            dl_cons = widgets.Button(description="Télécharger Consistency", icon="download", layout=widgets.Layout(width="200px"))
-            dl_geom = widgets.Button(description="Télécharger Géométrie", icon="download", layout=widgets.Layout(width="200px"))
-            dl_spec = widgets.Button(description="Télécharger Spectre", icon="download", layout=widgets.Layout(width="200px"))
+            dl_conv = widgets.Button(description="Télécharger Convergence", icon="download", layout=widgets.Layout(width="auto", flex="1 1 0%"))
+            dl_cons = widgets.Button(description="Télécharger Consistency", icon="download", layout=widgets.Layout(width="auto", flex="1 1 0%"))
+            dl_geom = widgets.Button(description="Télécharger Géométrie", icon="download", layout=widgets.Layout(width="auto", flex="1 1 0%"))
+            dl_spec = widgets.Button(description="Télécharger Spectre", icon="download", layout=widgets.Layout(width="auto", flex="1 1 0%"))
             # Callback : exporte l’axe voulu
             dl_conv.on_click(lambda _: self._export_subplot(ax0, "convergence"))
             dl_cons.on_click(lambda _: self._export_subplot(ax1, "consistency"))
@@ -2699,7 +2699,7 @@ class OptimizationTab:
         # ————————————————
         square_checkbox = widgets.Checkbox(
             value=False, description="Square ratio",
-            indent=False, layout=widgets.Layout(width="140px")
+            indent=False, layout=widgets.Layout(width="auto", flex="1 1 0%")
         )
         
         if thick_idx is None or width_idx is None:
@@ -2710,7 +2710,7 @@ class OptimizationTab:
         else:
             case_and_label = widgets.HBox(
                 [square_checkbox],
-                layout=widgets.Layout(align_items="center", min_width="140px", justify_content="flex-end")
+                layout=widgets.Layout(align_items="center", min_width="auto", flex="1 1 0%", justify_content="flex-end")
             )
 
             # Accolade très grande, centrée verticalement
@@ -2718,7 +2718,7 @@ class OptimizationTab:
                 <div style="display:flex;align-items:center;justify-content:center;height:60px;">
                     <span style="font-size:4.4em;line-height:0.7;">&#x7B;</span>
                 </div>
-            """, layout=widgets.Layout(width="32px", min_width="32px"))
+            """, layout=widgets.Layout(width="auto", flex="1 1 0%", min_width="auto", flex="1 1 0%"))
 
             _syncing = {"thick": False, "width": False}
 
@@ -2890,7 +2890,7 @@ class OptimizationTab:
         ok_btn = widgets.Button(
             description="OK",
             button_style="info",
-            layout=widgets.Layout(width="60px", display="none")  # caché par défaut
+            layout=widgets.Layout(width="auto", flex="1 1 0%", display="none")  # caché par défaut
         )
 
         def _dismiss_warning(_):
@@ -3081,17 +3081,17 @@ class OptimizationTab:
             # 2) boutons
             run_b    = widgets.Button(
                 description="Run ▶",
-                layout=widgets.Layout(width="80px"),
+                layout=widgets.Layout(width="auto", flex="1 1 0%"),
                 disabled=(job["status"] == "running")
             )
             cancel_b = widgets.Button(
                 description="Cancel ⏹",
-                layout=widgets.Layout(width="80px"),
+                layout=widgets.Layout(width="auto", flex="1 1 0%"),
                 disabled=(job["status"] not in ("running",))
             )
             delete_b = widgets.Button(
                 description="Delete ❌",
-                layout=widgets.Layout(width="80px"),
+                layout=widgets.Layout(width="auto", flex="1 1 0%"),
                 disabled=(job["status"] == "running")
             )
             
@@ -3101,11 +3101,11 @@ class OptimizationTab:
 
             # 3) ligne d’infos
             info_row = widgets.HBox([
-                widgets.Label(str(i),                             layout=widgets.Layout(width="30px")),
-                widgets.Label(job["config"],                      layout=widgets.Layout(width="150px")),
-                widgets.Label(job["cf_mode"],                     layout=widgets.Layout(width="80px")),
-                widgets.Label(f"{job['budget']}/{job['pop']}",    layout=widgets.Layout(width="80px")),
-                widgets.Label(status_ico,                         layout=widgets.Layout(width="30px")),
+                widgets.Label(str(i),                             layout=widgets.Layout(width="auto", flex="1 1 0%")),
+                widgets.Label(job["config"],                      layout=widgets.Layout(width="auto", flex="1 1 0%")),
+                widgets.Label(job["cf_mode"],                     layout=widgets.Layout(width="auto", flex="1 1 0%")),
+                widgets.Label(f"{job['budget']}/{job['pop']}",    layout=widgets.Layout(width="auto", flex="1 1 0%")),
+                widgets.Label(status_ico,                         layout=widgets.Layout(width="auto", flex="1 1 0%")),
                 run_b, cancel_b, delete_b
             ], layout=widgets.Layout(gap="10px"))
 

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/simulation/simulation.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/simulation/simulation.py
@@ -401,22 +401,22 @@ class SimulationTab:
         # ─── Spectre & points────────────────────────────────────────────────
         self.sim_lambda_min = widgets.FloatText(
             value=450.0, description="λ min (nm):",
-            layout=widgets.Layout(width='150px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         self.sim_lambda_max = widgets.FloatText(
             value=900.0, description="λ max (nm):",
-            layout=widgets.Layout(width='150px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         self.sim_n_points = widgets.IntText(
             value=300, description="Points:",
-            layout=widgets.Layout(width='150px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         self.sim_n_mod = widgets.IntText(
             value=5,
-            layout=widgets.Layout(width='150px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         for w in (self.sim_lambda_min, self.sim_lambda_max, self.sim_n_points):
@@ -425,12 +425,12 @@ class SimulationTab:
         # ─── Métrique λ₀ / range ─────────────────────────────────────────────
         self.band_min_in = widgets.FloatText(
             value=650.0, description="λmin:",
-            layout=widgets.Layout(width='150px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         self.band_max_in = widgets.FloatText(
             value=750.0, description="λmax:",
-            layout=widgets.Layout(width='150px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         self.band_box_in = widgets.HBox(
@@ -446,11 +446,11 @@ class SimulationTab:
             value='dip',
             description='Compute R(λ):',
             style={'description_width':'initial'},
-            layout=widgets.Layout(width='220px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
         )
         self.lambda0_in = widgets.FloatText(
             value=700.0, description="λ₀ (nm):",
-            layout=widgets.Layout(width='130px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         # toggle λ₀ via méthode de classe
@@ -479,13 +479,13 @@ class SimulationTab:
             value='fixed',
             description='RCWA modes',
             style={'description_width':'initial'},
-            layout=widgets.Layout(width='220px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
         )
         self.custom_modes_box = widgets.VBox(
             value=5, min=1,
             description='n_mod',
             style={'description_width': 'initial'},
-            layout=widgets.Layout(width='400px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
             )
         
         self.custom_n_mod_inputs = {}
@@ -494,7 +494,7 @@ class SimulationTab:
         self.sim_files_dropdown  = widgets.Dropdown(
             options=list_sim_summary_files(summary_sim_dir),
             description="Sim files:",
-            layout=widgets.Layout(width='500px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
 
@@ -514,7 +514,7 @@ class SimulationTab:
         self.sim_name_widget     = widgets.Text(
             placeholder="Choose simulation name (or auto if empty)",
             description="Simulation name:",
-            layout=widgets.Layout(width='500px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
 
@@ -525,7 +525,7 @@ class SimulationTab:
             name = cfg["config_name"]
             chk = widgets.Checkbox(value=False, description=name, indent=False)
             dn  = widgets.Checkbox(value=False, description='Δn', indent=False,
-                    layout=widgets.Layout(width='46px'))
+                    layout=widgets.Layout(width='auto', flex='1 1 0%'))
             
             chk.observe(self._update_sim_run_button, names='value')
             
@@ -551,7 +551,7 @@ class SimulationTab:
                         layout=widgets.Layout(gap='10px')),
             *rows],
             layout=widgets.Layout(
-                width='500px',
+                width='auto', flex='1 1 0%',
                 height=f'{30 + visible*30}px',
                 overflow_y='auto',
                 border='1px solid lightgray',
@@ -566,7 +566,7 @@ class SimulationTab:
             description="Select Configs & Δn",
             value=True,                     # ← ouvert par défaut
             icon='caret-up',                # ← icône cohérente
-            layout=widgets.Layout(width='520px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             button_style='warning'
         )
 
@@ -585,13 +585,13 @@ class SimulationTab:
         self.layer_selector     = widgets.SelectMultiple(
             options=layer_keys,
             description="Add Δn to layers:",
-            layout=widgets.Layout(width='300px', height='100px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%', height='100px'),
             style={'description_width':'initial'},
             disabled=True
         )
         self.delta_n_widget     = widgets.FloatText(
             value=1e-2, description="Δn:",
-            layout=widgets.Layout(width='150px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'initial'}
         )
         self.delta_n_widget.observe(_positive, names='value')
@@ -660,7 +660,7 @@ class SimulationTab:
             layout=widgets.Layout(
                 padding='10px',
                 border='1px solid lightgray',
-                min_width='320px'
+                min_width='auto', flex='1 1 0%'
             )
         )
 
@@ -1688,7 +1688,7 @@ class SimulationTab:
             chk_dn = widgets.Checkbox(
                 value=prev_dn.get(name, False),
                 description="Δn", indent=False,
-                layout=widgets.Layout(width="46px")
+                layout=widgets.Layout(width="auto", flex="1 1 0%")
             )
             # on rattache les observateurs existants
             chk_dn.observe(self._toggle_delta_widgets, names='value')
@@ -1731,7 +1731,7 @@ class SimulationTab:
             it = widgets.IntText(
                 value=self.sim_n_mod.value,
                 description=name,
-                layout=Layout(width='150px'),
+                layout=Layout(width='auto', flex='1 1 0%'),
                 style={'description_width':'initial'}
             )
             self.custom_n_mod_inputs[name] = it

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/geometry_settings.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/geometry_settings.py
@@ -181,10 +181,10 @@ def create_geometry_widget():
             value=default, min=min_val, max=max_val, step=0.1,
             description=description_str,
             continuous_update=False,
-            layout=widgets.Layout(width='350px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width': '180px'}
         )
-        float_text = widgets.FloatText(value=default, layout=widgets.Layout(width='100px'))
+        float_text = widgets.FloatText(value=default, layout=widgets.Layout(width='auto', flex='1 1 0%'))
         widgets.jslink((slider, 'value'), (float_text, 'value'))
         
         # Empêche les valeurs négatives
@@ -206,7 +206,7 @@ def create_geometry_widget():
     )
     button_add_layer = widgets.Button(
         description="Add layer", button_style='info',
-        layout=widgets.Layout(width='150px', margin='10px 0 0 0')
+        layout=widgets.Layout(width='auto', flex='1 1 0%', margin='10px 0 0 0')
     )
 
 
@@ -229,19 +229,19 @@ def create_geometry_widget():
         # Création du Text pour le nom de layer et du slider pour l'épaisseur
         name_w = widgets.Text(
             value=default_name, placeholder='Layer name',
-            layout=widgets.Layout(width='120px')
+            layout=widgets.Layout(width='auto', flex='1 1 0%')
         )
         sl = widgets.FloatSlider(
             value=1.0, min=0, max=50, step=0.1,
             description="thick (nm):", continuous_update=False,
-            layout=widgets.Layout(width='250px'),
+            layout=widgets.Layout(width='auto', flex='1 1 0%'),
             style={'description_width':'100px'}
         )
-        ft = widgets.FloatText(value=1.0, layout=widgets.Layout(width='80px'))
+        ft = widgets.FloatText(value=1.0, layout=widgets.Layout(width='auto', flex='1 1 0%'))
         widgets.jslink((sl, 'value'), (ft, 'value'))
 
         # Bouton de suppression
-        btn_del = widgets.Button(description="✕", layout=widgets.Layout(width='30px'))
+        btn_del = widgets.Button(description="✕", layout=widgets.Layout(width='auto', flex='1 1 0%'))
         container = widgets.HBox([name_w, sl, ft, btn_del])
 
 
@@ -307,26 +307,26 @@ def create_geometry_widget():
     # 4) Widgets de configuration existants (Add/Save/Load/Update/Delete) …
     config_name_text = widgets.Text(
         value='', placeholder='Configuration Name', description='Config Name :',
-        layout=widgets.Layout(width='350px'), style={'description_width':'180px'}
+        layout=widgets.Layout(width='auto', flex='1 1 0%'), style={'description_width':'180px'}
     )
     compartment_text = widgets.Text(
         value='', placeholder='Nom du compartiment', description='Compartiment :',
-        layout=widgets.Layout(width='350px'), style={'description_width':'180px'}
+        layout=widgets.Layout(width='auto', flex='1 1 0%'), style={'description_width':'180px'}
     )
-    button_add    = widgets.Button(description="Add Config",    layout=widgets.Layout(width='150px'))
+    button_add    = widgets.Button(description="Add Config",    layout=widgets.Layout(width='auto', flex='1 1 0%'))
     button_save   = widgets.Button(description="Save & Quit", button_style='success',
-                                  layout=widgets.Layout(width='200px'))
+                                  layout=widgets.Layout(width='auto', flex='1 1 0%'))
     config_dropdown = widgets.Dropdown(options=[], description="Saved Configs :",
-                                       layout=widgets.Layout(width='350px'),
+                                       layout=widgets.Layout(width='auto', flex='1 1 0%'),
                                        style={'description_width':'180px'})
-    button_load   = widgets.Button(description="Load",    layout=widgets.Layout(width='100px'))
-    button_update = widgets.Button(description="Update",  layout=widgets.Layout(width='120px'))
+    button_load   = widgets.Button(description="Load",    layout=widgets.Layout(width='auto', flex='1 1 0%'))
+    button_update = widgets.Button(description="Update",  layout=widgets.Layout(width='auto', flex='1 1 0%'))
     button_delete = widgets.Button(description="Delete",  button_style='danger',
-                                  layout=widgets.Layout(width='120px'))
+                                  layout=widgets.Layout(width='auto', flex='1 1 0%'))
 
     compartment_filter = widgets.Dropdown(
         options=["Tous"], value="Tous", description="Filtrer Compart.:",
-        layout=widgets.Layout(width='350px'),
+        layout=widgets.Layout(width='auto', flex='1 1 0%'),
         style={'description_width':'180px'}
     )
     output_area = widgets.Output(layout=widgets.Layout(padding='10px'))
@@ -708,7 +708,7 @@ def create_geometry_widget():
         output_area
     ])
     left_panel  = widgets.VBox(slider_widgets + [config_controls],
-                              layout=widgets.Layout(width='600px'))
+                              layout=widgets.Layout(width='auto', flex='1 1 0%'))
     right_panel = widgets.VBox([fig_output],
                               layout=widgets.Layout(flex='1'))
     main_ui = widgets.HBox([left_panel, right_panel],

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/material_selector.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/material_selector.py
@@ -838,7 +838,7 @@ class MaterialSelectorTabbedNotebook:
         self.geometry_dropdown = widgets.Dropdown(
             options=[""] + _load_geometry_names(),
             description="Geometry:",
-            layout=widgets.Layout(width="300px")
+            layout=widgets.Layout(width="auto", flex="1 1 0%")
         )
         self.geometry_dropdown.observe(self._on_geometry_change, names="value")
 


### PR DESCRIPTION
## Summary
- remove fixed pixel widths in geometry settings
- make material selector dropdown responsive
- update geometry/material config composer layout
- adjust simulation controls for flexbox responsiveness
- clean convergence and optimisation widgets for auto sizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd61272f8833396e788c7c7cdec14