### PR TITLE
Fix toggle button layouts

### DIFF
--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/optimisation/optimisation.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/optimisation/optimisation.py
@@ -552,7 +552,7 @@ class OptimizationTab:
             value=True,                      # ouvert par défaut
             icon="caret-up",
             button_style="warning",
-            layout=widgets.Layout(width="auto", flex="1 1 0%")
+            layout=widgets.Layout(width="auto", flex="0 0 auto")
         )
         self.opt_toggle_btn.observe(self._toggle_config_list, names="value")
 

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/simulation/simulation.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/simulation/simulation.py
@@ -566,7 +566,7 @@ class SimulationTab:
             description="Select Configs & Δn",
             value=True,                     # ← ouvert par défaut
             icon='caret-up',                # ← icône cohérente
-            layout=widgets.Layout(width='auto', flex='1 1 0%'),
+            layout=widgets.Layout(width='auto', flex='0 0 auto'),
             button_style='warning'
         )
 


### PR DESCRIPTION
## Summary
- keep config selector buttons compact in Simulation and Optimisation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808ac4487c8333aab6d39e7c7c22f5