### PR TITLE
Fix duplicate flex argument in optimisation layout

### DIFF
--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/optimisation/optimisation.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/optimisation/optimisation.py
@@ -2718,7 +2718,7 @@ class OptimizationTab:
                 <div style="display:flex;align-items:center;justify-content:center;height:60px;">
                     <span style="font-size:4.4em;line-height:0.7;">&#x7B;</span>
                 </div>
-            """, layout=widgets.Layout(width="auto", flex="1 1 0%", min_width="auto", flex="1 1 0%"))
+            """, layout=widgets.Layout(width="auto", min_width="auto", flex="1 1 0%"))
 
             _syncing = {"thick": False, "width": False}
 


### PR DESCRIPTION
## Summary
- remove redundant flex arg when building accolade widget layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808ac75e9c8333b9880f42a73f1d86