### PR TITLE
Fix blank lines on widget init

### DIFF
--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/simulation/simulation.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/simulation/simulation.py
@@ -19,6 +19,7 @@ import matplotlib as mpl
 mpl.use('module://ipympl.backend_nbagg')
 
 import os, io, base64, json, textwrap, sys
+import contextlib
 from copy import deepcopy
 from datetime import datetime
 
@@ -253,7 +254,9 @@ class SimulationTab:
         # 4) construction des panneaux (panels)
         # ── Initialise 1 seule figure + 2 axes ───────────────────────────
         # 1) Active le backend 'widget' pour ipympl (une seule fois)
-        get_ipython().run_line_magic('matplotlib', 'widget')
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            get_ipython().run_line_magic('matplotlib', 'widget')
         # 2) Désactive l’auto-affichage des figures, sinon plt.subplots() 
         #    injecte une figure dans la cellule
         plt.ioff()


### PR DESCRIPTION
## Summary
- avoid extra output when activating ipympl backend

## Testing
- `python -m py_compile Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/simulation/simulation.py`
- `pip install ipywidgets` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688090e3330c833384f3a447d7302ac0