### PR TITLE
Improve widget styling

### DIFF
--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/__init__.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/__init__.py
@@ -1,0 +1,17 @@
+"""UI package initialization with custom CSS for widgets."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from IPython.display import HTML, display
+
+
+def _load_custom_css() -> None:
+    css_path = Path(__file__).with_name("widgets.css")
+    if css_path.exists():
+        with css_path.open("r", encoding="utf-8") as f:
+            css = f.read()
+        display(HTML(f"<style>{css}</style>"))
+
+
+_load_custom_css()

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/widgets.css
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/ui/widgets.css
@@ -1,0 +1,21 @@
+/* Responsive styling for ipywidgets */
+.widget-button,
+.widget-toggle-button,
+.widget-dropdown,
+.widget-select,
+.widget-text,
+.widget-textarea,
+.widget-checkbox,
+.widget-radio-box {
+    width: auto !important;
+    max-width: 100%;
+    margin: 2px;
+}
+
+.widget-hbox,
+.widget-vbox {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ intéractive sous Jupyter/Voila.
 | **Export** | PNG, CSV, HDF5 (`simulation_results.h5`). |
 
 
+
+## Interface utilisateur
+Le sous-paquet `gap_plasmon_2d.ui` charge désormais automatiquement une feuille de style qui rend les widgets plus compacts et mieux alignés. Les boutons, listes déroulantes et cases à cocher s'adaptent à leur contenu pour une présentation plus harmonieuse.


### PR DESCRIPTION
## Summary
- add a CSS sheet for compact, centered widgets
- load the CSS automatically when importing `gap_plasmon_2d.ui`
- document the new styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688094b193f48333b4bff74bb7fa0ea8