### PR TITLE
Fix FloatText None handling

### DIFF
--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/__init__.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/__init__.py
@@ -1,2 +1,10 @@
 from gap_plasmon_2d.utils.logging_setup import setup_subpackage_loggers
 setup_subpackage_loggers()
+
+# Ensure FloatText widgets do not fail when cleared
+try:
+    import ipywidgets as widgets
+    from .utils.widgets import SafeFloatText
+    widgets.FloatText = SafeFloatText
+except Exception:
+    pass

--- a/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/utils/widgets.py
+++ b/Gap_Plasmon_2D/Workspace/src/gap_plasmon_2d/utils/widgets.py
@@ -1,0 +1,10 @@
+import ipywidgets as widgets
+import traitlets
+
+class SafeFloatText(widgets.FloatText):
+    """FloatText that treats ``None`` as 0.0 to avoid trait errors."""
+    value = traitlets.CFloat(default_value=0.0, allow_none=True).tag(sync=True)
+
+    @traitlets.validate('value')
+    def _valid_value(self, proposal):
+        return 0.0 if proposal['value'] is None else proposal['value']


### PR DESCRIPTION
## Summary
- create SafeFloatText widget to avoid trait errors when value becomes `None`
- patch package init to use SafeFloatText everywhere

## Testing
- `pip install -e .` *(fails: Could not install build dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6880971b09448333af311ecb7929b805